### PR TITLE
fix for multi unicode chars.

### DIFF
--- a/pyjavapropertiesu.py
+++ b/pyjavapropertiesu.py
@@ -14,7 +14,8 @@ import pyjavaproperties
 
 
 def unicode_escape_handler(e):
-    return (u'\\u%04x' % ord(e.object[e.start:e.end]), e.end)
+    s = ''.join(u'\\u%04x' % ord(x) for x in e.object[e.start:e.end])
+    return (s, e.end)
 
 
 codecs.register_error('unicode_escape', unicode_escape_handler)


### PR DESCRIPTION
Japanese user needs encoding unicode string such as u"テスト".
but, currently only support single character at once.

This PR fix this problem.
