### PR TITLE
Fix incorrect usage of decode function.

### DIFF
--- a/pyjavapropertiesu.py
+++ b/pyjavapropertiesu.py
@@ -41,4 +41,4 @@ def encode_unicode(value):
 
 
 def decode_unicode(value):
-    return value.decode('unicode_escape')
+    return value.decode('ascii', 'unicode_escape')


### PR DESCRIPTION
The decode function was used in the code as if it had no "encoding"
parameter.

The correct signature of the decode function is:
- `str.decode([encoding[, errors]])`

(see: [Documentation of str.decode](https://docs.python.org/2.7/library/stdtypes.html#str.decode))